### PR TITLE
The old WIP url doesn't work anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configuration
 Download this example project from GitHub and run the following commands:
 
     $ ionic platform add android
-    $ cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-inappbrowser.git
+    $ cordova plugin add org.apache.cordova.inappbrowser
 
 The above commands will add the Android build platform and install the required Apache InAppBrowser plugin.
 


### PR DESCRIPTION
This change just updates the README with the new project url. I tried the old link and it looked like everything installed correctly but when running the app on my device the application throws an exception and can't fin the inapp browser plugin. This new link fixes that problem. 
